### PR TITLE
モンテカルロ木探索を利用したボットを作成する

### DIFF
--- a/src/components/views/playground.tsx
+++ b/src/components/views/playground.tsx
@@ -6,6 +6,7 @@ import BottomPanel from "./BottomPanel";
 import TopPanel from "./TopPanel";
 import { useEffect } from "react";
 import { shoudSkip } from "../../hooks/othello/logic/analyze";
+import { MCTS } from "../../hooks/bot/methods/MCTS";
 
 const PlayGround: React.FC = () => {
   const [state, dispatch] = useOthello();
@@ -18,8 +19,10 @@ const PlayGround: React.FC = () => {
         dispatch({ type: "skip" });
       }
 
-      const result = calculate(state.board, state.color);
-      dispatch({ type: "update", fieldId: result });
+      const result = MCTS(state.board, state.color);
+      result
+        ? dispatch({ type: "update", fieldId: result })
+        : dispatch({ type: "skip" });
 
       return () => {
         clearTimeout(timeoutId);

--- a/src/hooks/bot/BotTypes.ts
+++ b/src/hooks/bot/BotTypes.ts
@@ -1,7 +1,7 @@
 import { BoardData } from "../../components/parts/board";
 import { FieldId } from "../../components/parts/field";
 import { ColorCode } from "../../components/parts/stone";
-import { randomBot } from "./bots/RandomBot";
+import { randomBot } from "./methods/Random";
 
 export const BOT_TYPES = {
   RANDOM: "RANDOM",
@@ -15,4 +15,4 @@ export const resolve: Resolver = (botType) => {
   return randomBot;
 };
 
-export type Calculator = (board: BoardData, color: ColorCode) => FieldId;
+export type Calculator = (board: BoardData, color: ColorCode) => FieldId | null;

--- a/src/hooks/bot/methods/MCTS.ts
+++ b/src/hooks/bot/methods/MCTS.ts
@@ -1,0 +1,90 @@
+import { BoardData } from "../../../components/parts/board";
+import { ColorCode, flip } from "../../../components/parts/stone";
+import {
+  countStone,
+  rest,
+  selectableFields,
+} from "../../othello/logic/analyze";
+import { move } from "../../othello/logic/core";
+import { randomBot } from "./Random";
+
+type Options = {
+  maxPlayOut: number;
+};
+
+export const MCTS = (board: BoardData, color: ColorCode) => {
+  const options: Options = {
+    maxPlayOut: 500,
+  };
+  
+  // 選択する候補となるフィールドのリスト
+  const fields = selectableFields(board, color);
+
+  if (fields.length === 0) return null;
+
+  // ひとつのフィールドに対し何回プレイアウトを行うか決定
+  const eachPlayOutCount = Math.floor(options.maxPlayOut / fields.length);
+
+  const start = new Date();
+
+  // プレイアウトの結果を評価する
+  const playOutResults = fields.reduce(
+    (acc, field) => {
+      const score = evaluateMove(board, color, field, eachPlayOutCount);
+      return score > acc.score ? { field, score } : acc;
+    },
+    { field: -1, score: -1 }
+  );
+
+  console.log((new Date().getTime() - start.getTime()) + 'ms');
+  console.log(playOutResults);
+  
+
+  return playOutResults.field;
+};
+
+// プレイアウトの結果を評価する
+const evaluateMove = (
+  board: BoardData,
+  color: ColorCode,
+  field: number,
+  playOutCount: number
+) => {
+  let winCount = 0;
+  for (let i = 0; i < playOutCount; i++) {
+    winCount += playOut(board, color, field) ? 1 : 0;
+  }
+  
+  return winCount / playOutCount;
+};
+
+const playOut = (
+  baseBoard: BoardData,
+  myColor: ColorCode,
+  targetField: number
+): boolean => {
+  // まずは指定されたフィールドに石を置く
+  let board = move(baseBoard, targetField, myColor);
+  // 相手の手番からシミュレーション開始
+  let color = flip(myColor);
+  let skipCount = 0;
+  try {
+    while (rest(board) !== 0) {
+      const result = randomBot(board, color);
+      if (result !== null) {
+        board = move(board, result, color);
+        skipCount = 0;
+      } else {
+        skipCount++;
+      }
+      color = flip(color);
+      if (skipCount > 1) {
+        throw new Error('パスが連続しています');
+      }
+    }
+    return countStone(board, myColor) > countStone(board, flip(myColor));
+  } catch (e) {
+    // 勝敗がつかない場合は負け扱いにする
+    return false;
+  }
+};

--- a/src/hooks/bot/methods/Random.ts
+++ b/src/hooks/bot/methods/Random.ts
@@ -4,8 +4,10 @@ import { selectableFields } from "../../othello/logic/analyze";
 import { Calculator } from "../BotTypes";
 
 export const randomBot: Calculator = (board: BoardData, color: ColorCode) => {
- const fields = selectableFields(board, color);
- const i = Math.floor(Math.random() * fields.length);
+  const fields = selectableFields(board, color);
+  if (fields.length === 0) return null;
 
- return fields[i];
+  const i = Math.floor(Math.random() * fields.length);
+
+  return fields[i];
 };


### PR DESCRIPTION
## 背景
[ゲームAI技術入門──広大な人工知能の世界を体系的に学ぶ](https://gihyo.jp/book/2019/978-4-297-10828-1) を読んでモンテカルロ木探索(通称MCTS)に興味を持った

## やったこと
* モンテカルロ木探索を行う`MCTS()`を実装
  * デバッグも兼ねて計算時間と最適手の勝率をconsole.log()に表示したままにした
* トップ画面アクセス時の対戦相手をボットからMCTSに変更

## やらなかったこと
* 勝率の計測
  * 体感ではかなり強くなっているが定量的な計測は行っていない
* 計算の最適化
  * どんな局面でも固定で500回プレイアウトを行っている
  * 複数の候補がある場合は、`500 / 候補数` で重み付けをせずにリソースを分配
 
現状では自身のM1 Mac ローカル環境で序盤は700ms前後、終盤は最短10ms程度でほぼ線形に計算時間が減少