### PR TITLE
スキップボタンの位置を盤面に近づけた

### DIFF
--- a/src/components/PlayGround/PlayGround.tsx
+++ b/src/components/PlayGround/PlayGround.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Board from "./elements/Board/Board";
-import BottomPanel from "./elements/BottomPanel/BottomPanel";
+import BottomPanel from "./elements/ActionPanel/BottomPanel";
 import { useEffect } from "react";
 import { MCTS } from "../shared/hooks/bot/methods/MCTS";
 import InfoPanel from "./elements/InfoPanel/InfoPanel";

--- a/src/components/PlayGround/elements/ActionPanel/BottomPanel.tsx
+++ b/src/components/PlayGround/elements/ActionPanel/BottomPanel.tsx
@@ -5,8 +5,8 @@ import useOthello from "../../../../dataflow/othello/othello";
 const BottomPanel: React.FC = () => {
   const { state, skip } = useOthello();
   return (
-    <>
-      <div className="text-center h-full flex justify-center items-center">
+    <div className="text-center h-full flex justify-center items-start pt-8">
+      <div>
         {shoudSkip(state.board, state.color) && rest(state.board) !== 0 ? (
           <button
             className="block bg-sky-400 text-slate-50 p-1 w-20 rounded-md"
@@ -16,7 +16,7 @@ const BottomPanel: React.FC = () => {
           </button>
         ) : undefined}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/components/PlayGround/elements/InfoPanel/elements/PlayerInfo/PlayerInfo.tsx
+++ b/src/components/PlayGround/elements/InfoPanel/elements/PlayerInfo/PlayerInfo.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { shoudSkip } from "../../../../../../dataflow/othello/logic/analyze";
 import useOthello from "../../../../../../dataflow/othello/othello";
 import { COLOR_CODES } from "../../../Board/Stone";
 import PlayerBar from "./PlayerBar";
@@ -12,7 +13,7 @@ const PlayerInfo: React.FC = (props) => {
           message: "あなたのターンです",
           name: "You",
           theme: "light",
-          status: "",
+          status: shoudSkip(state.board, state.color) ? "置ける場所がありません" : "",
         }
       : {
           message: "相手のターンです",


### PR DESCRIPTION
## 背景
スマートフォンでプレイ時にスキップボタンが検索バーで見えなくなることがあった

## やったこと
* スキップボタンを盤面に近づけた
* 盤面下部のコンポーネント名をActionPanelに変更した

本当はスマホ特有の検索バーも考慮した画面レイアウトの調整が必要だが、暫定対応としてボタン位置の変更を行った