### PR TITLE
ゲーム開始時にゲームモードを設定できるようにする

### DIFF
--- a/src/components/PlayGround/PlayGround.tsx
+++ b/src/components/PlayGround/PlayGround.tsx
@@ -3,24 +3,14 @@
 import Board from "./elements/Board/Board";
 import BottomPanel from "./elements/ActionPanel/BottomPanel";
 import { useEffect } from "react";
-import { MCTS } from "../shared/hooks/bot/methods/MCTS";
 import InfoPanel from "./elements/InfoPanel/InfoPanel";
-import { COLOR_CODES } from "./elements/Board/Stone";
 import useOthello from "../../dataflow/othello/othello";
 
 const PlayGround: React.FC = () => {
-  const { state, update, skip } = useOthello();
+  const { activateBot } = useOthello();
 
   useEffect(() => {
-    if (state.color === COLOR_CODES.WHITE || state.isOver) return;
-    const timeoutId = setTimeout(() => {
-      const result = MCTS(state.board, state.color);
-      result !== null ? update(result) : skip();
-
-      return () => {
-        clearTimeout(timeoutId);
-      };
-    }, 500);
+    activateBot();
   });
 
   return (

--- a/src/components/PlayGround/PlayGround.tsx
+++ b/src/components/PlayGround/PlayGround.tsx
@@ -10,7 +10,12 @@ const PlayGround: React.FC = () => {
   const { activateBot } = useOthello();
 
   useEffect(() => {
-    activateBot();
+    const timeoutId = setTimeout(() => {
+      activateBot();
+      return () => {
+        clearTimeout(timeoutId);
+      };
+    }, 500);
   });
 
   return (

--- a/src/components/PlayGround/elements/InfoPanel/InfoPanel.tsx
+++ b/src/components/PlayGround/elements/InfoPanel/InfoPanel.tsx
@@ -3,9 +3,14 @@
 import useOthello from "../../../../dataflow/othello/othello";
 import PlayerInfo from "./elements/PlayerInfo/PlayerInfo";
 import ResultInfo from "./elements/ResultInfo/ResultInfo";
+import SettingsInfo from "./elements/SettingsInfo/SettingsInfo";
 
 const InfoPanel: React.FC = () => {
   const { state } = useOthello();
+
+  if (!state.isInitialized) {
+    return <SettingsInfo />;
+  }
   return state.isOver ? <ResultInfo /> : <PlayerInfo />;
 };
 

--- a/src/components/PlayGround/elements/InfoPanel/elements/PlayerInfo/PlayerInfo.tsx
+++ b/src/components/PlayGround/elements/InfoPanel/elements/PlayerInfo/PlayerInfo.tsx
@@ -7,18 +7,21 @@ import PlayerBar from "./PlayerBar";
 
 const PlayerInfo: React.FC = (props) => {
   const { state } = useOthello();
+
+  const colorText = state.color === COLOR_CODES.WHITE ? "白" : "黒";
+  const theme = state.color === COLOR_CODES.WHITE ? "light" : "dark";
+  const name = state.players[state.color].name;
+
   const data =
-    state.color === COLOR_CODES.WHITE
+    state.players[state.color].type === "human"
       ? {
-          message: "あなたのターンです",
-          name: "You",
-          theme: "light",
-          status: shoudSkip(state.board, state.color) ? "置ける場所がありません" : "",
+          message: colorText + "プレイヤーのターンです",
+          status: shoudSkip(state.board, state.color)
+            ? "置ける場所がありません"
+            : state.error?.message ?? "",
         }
       : {
           message: "相手のターンです",
-          name: "Bot Lv.5",
-          theme: "dark",
           status: "思考中...",
         };
 
@@ -26,8 +29,8 @@ const PlayerInfo: React.FC = (props) => {
     <div className=" h-full text-center flex flex-col items-center sm:justify-center pb-6 sm:pt-6 pt-10">
       <h2 className="text-slate-600 font-bold text-xl mb-6">{data.message}</h2>
       <div className="mb-1">
-        <PlayerBar theme={data.theme as "light" | "dark"}>
-          {data.name}
+        <PlayerBar theme={theme}>
+          {name}
         </PlayerBar>
       </div>
       <p className="text-xs text-slate-400 animate-pulse h-4">{data.status}</p>

--- a/src/components/PlayGround/elements/InfoPanel/elements/ResultInfo/ResultInfo.tsx
+++ b/src/components/PlayGround/elements/InfoPanel/elements/ResultInfo/ResultInfo.tsx
@@ -18,8 +18,8 @@ const ResultInfo: React.FC = (props) => {
       <h2 className="text-slate-600 font-bold text-xl mb-6">
         {counts.white + counts.black === TOTAL_STONES
           ? counts.white > counts.black
-            ? "You Win!!"
-            : "You Lose..."
+            ? state.players[COLOR_CODES.WHITE].name + " Win!"
+            : state.players[COLOR_CODES.BLACK].name + " Win!"
           : "Draw Game"}
       </h2>
       <div className="mb-1">

--- a/src/components/PlayGround/elements/InfoPanel/elements/SettingsInfo/SettingsInfo.tsx
+++ b/src/components/PlayGround/elements/InfoPanel/elements/SettingsInfo/SettingsInfo.tsx
@@ -12,13 +12,13 @@ const SettingsInfo: React.FC = (props) => {
   const [isPvE, setIsPvE] = useState(false);
 
   const handlePvP = () => {
-    initialize({ gameMode: GAME_MODE.PVP, players: ["player1", "player2"] });
+    initialize({ gameMode: GAME_MODE.PVP, players: ["Player1", "Player2"] });
   };
 
   const handlePvE = (name: string, playerColor: ColorCode) => {
     initialize({
       gameMode: GAME_MODE.PVE,
-      players: name,
+      player: name,
       playerColor: playerColor,
     });
   };
@@ -52,13 +52,13 @@ const SettingsInfo: React.FC = (props) => {
             <div className="flex justify-center gap-5">
               <div
                 className="flex gap-2 items-center"
-                onClick={() => handlePvE("プレイヤー", COLOR_CODES.WHITE)}
+                onClick={() => handlePvE("Player1", COLOR_CODES.WHITE)}
               >
                 <button className="text-sm text-slate-700">先攻</button>
               </div>
               <div
                 className="flex gap-2 items-center"
-                onClick={() => handlePvE("プレイヤー", COLOR_CODES.BLACK)}
+                onClick={() => handlePvE("Player1", COLOR_CODES.BLACK)}
               >
                 <button className="text-sm text-slate-700">後攻</button>
               </div>

--- a/src/components/PlayGround/elements/InfoPanel/elements/SettingsInfo/SettingsInfo.tsx
+++ b/src/components/PlayGround/elements/InfoPanel/elements/SettingsInfo/SettingsInfo.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import useOthello, {
+  GAME_MODE,
+} from "../../../../../../dataflow/othello/othello";
+import Stone, { ColorCode, COLOR_CODES } from "../../../Board/Stone";
+
+const SettingsInfo: React.FC = (props) => {
+  const { initialize } = useOthello();
+
+  const [isPvE, setIsPvE] = useState(false);
+
+  const handlePvP = () => {
+    initialize({ gameMode: GAME_MODE.PVP, players: ["player1", "player2"] });
+  };
+
+  const handlePvE = (name: string, playerColor: ColorCode) => {
+    initialize({
+      gameMode: GAME_MODE.PVE,
+      players: name,
+      playerColor: playerColor,
+    });
+  };
+
+  return (
+    <div className=" h-full text-center flex flex-col items-center sm:justify-center pb-6 sm:pt-6 pt-10">
+      <h2 className="text-slate-600 font-bold text-xl mb-">NEW GAME</h2>
+      <p className="text-xs text-slate-400 h-4">
+        ゲームモードを選択してください
+      </p>
+      <div className="mt-6 flex flex-col gap-2">
+        {isPvE ? undefined : (
+          <button
+            className="text-slate-700 text-sm font-bold hover:text-slate-400"
+            onClick={handlePvP}
+          >
+            プレイヤー対戦
+          </button>
+        )}
+        <button
+          className="text-slate-700 text-sm font-bold hover:text-slate-400"
+          onClick={() => setIsPvE(true)}
+        >
+          ボット対戦
+        </button>
+        {isPvE ? (
+          <>
+            <p className="text-xs text-slate-400 h-4">
+              プレーする順番を選択してください
+            </p>
+            <div className="flex justify-center gap-5">
+              <div
+                className="flex gap-2 items-center"
+                onClick={() => handlePvE("プレイヤー", COLOR_CODES.WHITE)}
+              >
+                <button className="text-sm text-slate-700">先攻</button>
+              </div>
+              <div
+                className="flex gap-2 items-center"
+                onClick={() => handlePvE("プレイヤー", COLOR_CODES.BLACK)}
+              >
+                <button className="text-sm text-slate-700">後攻</button>
+              </div>
+            </div>
+          </>
+        ) : undefined}
+      </div>
+    </div>
+  );
+};
+
+export default SettingsInfo;

--- a/src/dataflow/othello/othello.ts
+++ b/src/dataflow/othello/othello.ts
@@ -33,7 +33,7 @@ const initPlayer = (name: string): Player => {
 
 const initBot = (): Player => {
   return {
-    name: "Bot",
+    name: "Bot Lv.5",
     type: "bot",
     think: async (board: BoardData, color: ColorCode) => MCTS(board, color),
   };
@@ -142,7 +142,7 @@ export type PvPSettings = {
 
 export type PvESettings = {
   gameMode: GAME_MODE.PVE;
-  players: string;
+  player: string;
   playerColor: ColorCode;
 };
 
@@ -199,11 +199,11 @@ const useOthello = create<State & Actions>((set, get) => ({
         : {
             [COLOR_CODES.WHITE]:
               settings.playerColor === COLOR_CODES.WHITE
-                ? initPlayer(settings.players)
+                ? initPlayer(settings.player)
                 : initBot(),
             [COLOR_CODES.BLACK]:
               settings.playerColor === COLOR_CODES.BLACK
-                ? initPlayer(settings.players)
+                ? initPlayer(settings.player)
                 : initBot(),
           };
 


### PR DESCRIPTION
## 背景
現状ではプレイヤーが自身のプレーする色(先攻/後攻)や対戦相手を選べなかった
- コード上でハードコーディングされていたため
  - プレイヤーは白
  - 対戦相手はモンテカルロ木探索のBotで固定

##  やったこと
- ゲーム開始時にゲームモードを選べるようにした
  - プレイヤー対戦(PVP)
  - ボット対戦(PVE)
- すぐにゲームを開始できるよう、ゲームモードを選択せずに盤面をクリックした場合は自動的にPVPになる

### やっていないこと
- デザインの確定
- ゲームモード選択時の戻るボタンの実装
- ゲームモードの永続化(リスタート機能など)