### PR TITLE
着手履歴を記録し、undo/redoが行えるようにした

### DIFF
--- a/src/components/PlayGround/elements/ActionPanel/BottomPanel.tsx
+++ b/src/components/PlayGround/elements/ActionPanel/BottomPanel.tsx
@@ -4,11 +4,26 @@ import useOthello from "../../../../dataflow/othello/othello";
 
 const BottomPanel: React.FC = () => {
   const [isVisible, setIsVisible] = useState(false);
-  const { state, skip, undo, redo, index, moveHistory } = useOthello();
+  const { state, skip, undo, redo, canUndo, canRedo } = useOthello();
   return (
-    <div className="text-center h-full flex flex-col justify-start items-center" onDoubleClick={() => {setIsVisible(!isVisible)}}>
-      <div className={"mt-3 flex justify-between gap-36 " + (isVisible ?"" : "hidden")}>
-        <button className={"w-10 h-10 bg-slate-100 rounded-full p-2 " + (index === -1 ? 'text-slate-400': '')} onClick={undo}>
+    <div
+      className="text-center h-full flex flex-col justify-start items-center"
+      onDoubleClick={() => {
+        setIsVisible(!isVisible);
+      }}
+    >
+      <div
+        className={
+          "mt-3 flex justify-between gap-36 " + (isVisible ? "" : "hidden")
+        }
+      >
+        <button
+          className={
+            "w-10 h-10 bg-slate-100 rounded-full p-2 " +
+            (canUndo() ? "" : "text-slate-400")
+          }
+          onClick={undo}
+        >
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -24,7 +39,10 @@ const BottomPanel: React.FC = () => {
           </svg>
         </button>
         <button
-          className={"w-10 h-10 bg-slate-100 rounded-full p-2 " + (index < moveHistory.length ? 'text-slate-400': '')}
+          className={
+            "w-10 h-10 bg-slate-100 rounded-full p-2 " +
+            (canRedo() ? "" : "text-slate-400")
+          }
           onClick={redo}
         >
           <svg

--- a/src/components/PlayGround/elements/ActionPanel/BottomPanel.tsx
+++ b/src/components/PlayGround/elements/ActionPanel/BottomPanel.tsx
@@ -1,12 +1,48 @@
-import React from "react";
+import React, { useState } from "react";
 import { rest, shoudSkip } from "../../../../dataflow/othello/logic/analyze";
 import useOthello from "../../../../dataflow/othello/othello";
 
 const BottomPanel: React.FC = () => {
-  const { state, skip } = useOthello();
+  const [isVisible, setIsVisible] = useState(false);
+  const { state, skip, undo, redo, index, moveHistory } = useOthello();
   return (
-    <div className="text-center h-full flex justify-center items-start pt-8">
-      <div>
+    <div className="text-center h-full flex flex-col justify-start items-center" onDoubleClick={() => {setIsVisible(!isVisible)}}>
+      <div className={"mt-3 flex justify-between gap-36 " + (isVisible ?"" : "hidden")}>
+        <button className={"w-10 h-10 bg-slate-100 rounded-full p-2 " + (index === -1 ? 'text-slate-400': '')} onClick={undo}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3"
+            />
+          </svg>
+        </button>
+        <button
+          className={"w-10 h-10 bg-slate-100 rounded-full p-2 " + (index < moveHistory.length ? 'text-slate-400': '')}
+          onClick={redo}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15 15l6-6m0 0l-6-6m6 6H9a6 6 0 000 12h3"
+            />
+          </svg>
+        </button>
+      </div>
+      <div className="pt-6">
         {shoudSkip(state.board, state.color) && rest(state.board) !== 0 ? (
           <button
             className="block bg-sky-400 text-slate-50 p-1 w-20 rounded-md"

--- a/src/dataflow/othello/othello.ts
+++ b/src/dataflow/othello/othello.ts
@@ -148,8 +148,27 @@ export type PvESettings = {
 
 type GameSettings = PvPSettings | PvESettings;
 
+// == Move History =======================
+type UpdateMove = {
+  type: 'update';
+  putAt: FieldId;
+  flipped: FieldId[];
+};
+
+type SkipMove = {
+  type: 'skip';
+};
+
+type Move = UpdateMove | SkipMove;
+
+type MoveHistory = Array<{ color: ColorCode; move: Move }>;
+
+const initialHistory: MoveHistory = [];
+
 type State = {
   state: GameState;
+  moveHistory: MoveHistory;
+  index: number;
 };
 
 type Actions = {
@@ -158,23 +177,44 @@ type Actions = {
   reset: () => void;
   activateBot: () => void;
   initialize: (settings: GameSettings) => void;
+  push: (color: ColorCode, move: Move) => void;
 };
 
 const useOthello = create<State & Actions>((set, get) => ({
   state: initialState,
   update: (fieldId: number) => {
+    const stateBefore = get().state;
+  
     set((state) => ({
-      state: othelloReducer(state.state, { type: "update", fieldId }),
+      state: othelloReducer(state.state, { type: 'update', fieldId }),
     }));
+    const stateAfter = get().state;
+    
+    const initialValue = [] as number[];
+    const flipped = stateBefore.board.reduce(
+      (indexes, element, index) => {
+        return element !== stateAfter.board[index] && index !== fieldId
+          ? [...indexes, index]
+          : indexes;
+      },
+      initialValue
+    );
+    if (flipped.length === 0) {
+      return
+    }
+
+    get().push(stateBefore.color, { type: "update", putAt: fieldId, flipped })
+    console.log(get().moveHistory);
+    
   },
   skip: () =>
     set((state) => ({
-      state: othelloReducer(state.state, { type: "skip" }),
+      state: othelloReducer(state.state, { type: 'skip' }),
     })),
-  reset: () => set({ state: initialState }),
+  reset: () => set({ state: initialState, moveHistory: [], index: -1 }),
   activateBot: async () => {
     const state = get().state;
-    const isBotTurn = state.players[state.color].type === "bot";
+    const isBotTurn = state.players[state.color].type === 'bot';
     const update = get().update;
 
     if (state.isOver || !isBotTurn) {
@@ -182,7 +222,7 @@ const useOthello = create<State & Actions>((set, get) => ({
     }
 
     const think = state.players[state.color].think;
-    if (think === undefined) throw new Error("Botが登録されていません");
+    if (think === undefined) throw new Error('Botが登録されていません');
 
     const move = await think(state.board, state.color);
     if (move === null) return get().skip();
@@ -215,6 +255,18 @@ const useOthello = create<State & Actions>((set, get) => ({
       },
     });
   },
+  moveHistory: initialHistory,
+  index: -1,
+  push: (color, move) =>
+    set((state) => {
+      const newHistory = state.moveHistory
+        .slice(0, state.index + 1 )  // 未来の要素を削除
+        .concat({ color, move });  // 今回の追加要素を記録
+      return {
+        moveHistory: newHistory,
+        index: newHistory.length - 1,
+      };
+    }),
 }));
 
 export default useOthello;

--- a/src/dataflow/othello/othello.ts
+++ b/src/dataflow/othello/othello.ts
@@ -168,7 +168,6 @@ const initialHistory: MoveHistory[] = [];
 const apply =
   (direction: "back" | "forward") =>
   (board: BoardData, moveHistory: MoveHistory) => {
-    console.log(moveHistory);
     const { color, move } = moveHistory;
     const oppositeColor = flip(color);
     return move.type === "update"
@@ -300,32 +299,32 @@ const useOthello = create<State & Actions>((set, get) => ({
     }),
   undo: () =>
     set((state) => {
-      if (state.index < 0) {
+      if (!get().canUndo()) {
         return state;
       }
-      const newIndex = state.index - 1;
+
+      const prevIndex = state.index - 1;
       return {
         ...state,
         state: {
           ...state.state,
           turn: state.state.turn - 1,
-          board: apply("back")(
+          board: apply('back')(
             state.state.board,
             state.moveHistory[state.index]
           ),
           color: flip(state.state.color),
         },
-        index: newIndex,
+        index: prevIndex,
       };
     }),
   redo: () =>
     set((state) => {
-      const nextIndex = state.index + 1;
-      const lastIndex = state.moveHistory.length - 1;
-      if (nextIndex > lastIndex) {
+      if (!get().canRedo()) {
         return state;
       }
 
+      const nextIndex = state.index + 1;
       return {
         ...state,
         state: {
@@ -341,13 +340,12 @@ const useOthello = create<State & Actions>((set, get) => ({
       };
     }),
   canUndo: () => {
-    return get().index > -1;
+    return !get().state.isOver && get().index > -1;
   },
   canRedo: () => {
     const nextIndex = get().index + 1;
     const lastIndex = get().moveHistory.length - 1;
-    console.log(nextIndex, lastIndex);
-    return nextIndex <= lastIndex;
+    return !get().state.isOver && nextIndex <= lastIndex;
   },
 }));
 


### PR DESCRIPTION
## やったこと
- 着手履歴の記録
  - 差分を記録
     - アクション
     - 置いた場所
     - ひっくり返ったコマ 
   - コマを置いた際の差分表示UIへの利用やスキップが連続したかどうかの判定にも利用する想定
- undo/redoを実装
  - 着手履歴の差分データを元に盤面の状態を復元できるようにした