### PR TITLE
勝敗判定のロジックの修正

### DIFF
--- a/src/components/PlayGround/elements/InfoPanel/elements/ResultInfo/ResultInfo.tsx
+++ b/src/components/PlayGround/elements/InfoPanel/elements/ResultInfo/ResultInfo.tsx
@@ -2,25 +2,59 @@
 
 import { countStone } from "../../../../../../dataflow/othello/logic/analyze";
 import useOthello from "../../../../../../dataflow/othello/othello";
-import { COLOR_CODES } from "../../../Board/Stone";
+import { BoardData } from "../../../Board/Board";
+import { ColorCode, COLOR_CODES } from "../../../Board/Stone";
 import ResultBar from "./ResultBar";
 
 const TOTAL_STONES = 64;
 
-const ResultInfo: React.FC = (props) => {
-  const { state } = useOthello();
+const ResultInfo: React.FC = () => {
+  const { state, gameMode } = useOthello();
+
   const counts = {
     white: countStone(state.board, COLOR_CODES.WHITE),
     black: countStone(state.board, COLOR_CODES.BLACK),
   };
+
+  const getWinner = (board: BoardData): ColorCode | undefined => {
+    const counts = {
+      white: countStone(state.board, COLOR_CODES.WHITE),
+      black: countStone(state.board, COLOR_CODES.BLACK),
+    };
+
+    const isFinished = counts.white + counts.black === TOTAL_STONES;
+    const isDraw = counts.white === counts.black;
+    const isDominated = counts.white === 0 || counts.black === 0;
+
+    if (isFinished) {
+      // 全てのマスが埋まっている場合
+      return isDraw
+        ? undefined
+        : counts.white > counts.black
+        ? COLOR_CODES.WHITE
+        : COLOR_CODES.BLACK;
+    } else {
+      // 途中で終了した場合
+      return isDominated
+        ? counts.white > counts.black
+          ? COLOR_CODES.WHITE
+          : COLOR_CODES.BLACK
+        : undefined;
+    }
+  };
+
+  const winner = getWinner(state.board);
+
   return (
     <div className=" h-full text-center flex flex-col items-center sm:justify-center pb-6 sm:pt-6 pt-10">
       <h2 className="text-slate-600 font-bold text-xl mb-6">
-        {counts.white + counts.black === TOTAL_STONES
-          ? counts.white > counts.black
-            ? state.players[COLOR_CODES.WHITE].name + " Win!"
-            : state.players[COLOR_CODES.BLACK].name + " Win!"
-          : "Draw Game"}
+        {winner === undefined
+          ? "DRAW"
+          : gameMode === "PVP"
+          ? state.players[winner].name + " WIN!"
+          : state.players[winner].type === "human"
+          ? "YOU WIN!"
+          : "YOU LOSE..."}
       </h2>
       <div className="mb-1">
         <ResultBar counts={counts} />

--- a/src/dataflow/othello/othello.ts
+++ b/src/dataflow/othello/othello.ts
@@ -194,6 +194,7 @@ const apply =
 
 type State = {
   state: GameState;
+  gameMode: GAME_MODE;
   moveHistory: MoveHistory[];
   index: number;
 };
@@ -213,6 +214,7 @@ type Actions = {
 
 const useOthello = create<State & Actions>((set, get) => ({
   state: initialState,
+  gameMode: GAME_MODE.PVP,
   update: (fieldId: number) => {
     const stateBefore = get().state;
 
@@ -286,6 +288,7 @@ const useOthello = create<State & Actions>((set, get) => ({
         players,
         isInitialized: true,
       },
+      gameMode: settings.gameMode,
     });
   },
   moveHistory: initialHistory,
@@ -312,7 +315,7 @@ const useOthello = create<State & Actions>((set, get) => ({
         state: {
           ...state.state,
           turn: state.state.turn - 1,
-          board: apply("back")(
+          board: apply('back')(
             state.state.board,
             state.moveHistory[state.index]
           ),

--- a/src/dataflow/othello/othello.ts
+++ b/src/dataflow/othello/othello.ts
@@ -8,7 +8,7 @@ import {
   COLOR_CODES,
   flip,
 } from "../../components/PlayGround/elements/Board/Stone";
-import { rest } from "./logic/analyze";
+import { countStone, rest } from "./logic/analyze";
 import { move } from "./logic/core";
 import { create } from "zustand";
 import { MCTS } from "../../components/shared/hooks/bot/methods/MCTS";
@@ -87,8 +87,8 @@ const initialState: GameState = {
   board: initialBoard,
   color: initialColor,
   players: {
-    [COLOR_CODES.WHITE]: initPlayer("Player2"),
-    [COLOR_CODES.BLACK]: initPlayer("Player1"),
+    [COLOR_CODES.WHITE]: initPlayer("WHITE"),
+    [COLOR_CODES.BLACK]: initPlayer("BLACK"),
   },
   isInitialized: false,
 };
@@ -99,7 +99,10 @@ const othelloReducer = (state: GameState, action: Action): GameState => {
       try {
         const updated = move(state.board, action.fieldId, state.color);
         return {
-          isOver: rest(updated) === 0, // 置くところがなくなれば終了
+          isOver:
+            rest(updated) === 0 || // 置くところがなくなれば終了
+            countStone(updated, COLOR_CODES.WHITE) === 0 ||
+            countStone(updated, COLOR_CODES.WHITE) === 0,
           isSkipped: false,
           turn: state.turn + 1,
           board: updated,
@@ -309,7 +312,7 @@ const useOthello = create<State & Actions>((set, get) => ({
         state: {
           ...state.state,
           turn: state.state.turn - 1,
-          board: apply('back')(
+          board: apply("back")(
             state.state.board,
             state.moveHistory[state.index]
           ),


### PR DESCRIPTION
## やったこと
- ロジックの修正
  - 片方の色が全滅した時に試合終了するようにした
- 結果発表画面
  - 同点時に引き分け表示がされていなかった問題を修正
  - 片方の色が全滅した場合にもう片方が勝利するように修正