### PR TITLE
ゲームモードをHeaderに表示するようにした

### DIFF
--- a/src/components/shared/elements/Header/Header.tsx
+++ b/src/components/shared/elements/Header/Header.tsx
@@ -3,7 +3,7 @@
 import useOthello from "../../../../dataflow/othello/othello";
 
 const Header: React.FC = () => {
-  const { reset } = useOthello();
+  const { reset, gameMode } = useOthello();
 
   const handleNewGame = () => {
     if (confirm("プレイ中のゲーム情報が失われます。よろしいですか？")) {
@@ -14,15 +14,26 @@ const Header: React.FC = () => {
   return (
     <header>
       <div className="h-12 mx-[2rem] flex justify-between items-center">
-        <h1 className="font-bold text-slate-500 tracking-wide text-xl">
-          Othello
-        </h1>
-        <div className="flex justify-end gap-5">
+        <div className="basis-2/5 flex items-center gap-1">
+          <h1 className="font-bold text-slate-500 tracking-wide text-2xl">
+            Othello
+          </h1>
+          <div
+            className={
+              "w-fit text-xs text-slate-400 rounded-sm px-2 py-0.5 " +
+              (!!gameMode ? "border border-slate-400" : "")
+            }
+          >
+            {gameMode === undefined ? "" : gameMode === "PVP" ? "PVP" : "BOT"}
+          </div>
+        </div>
+        <div className="basis-1/5 flex justify-center"></div>
+        <div className="basis-2/5 flex justify-end gap-5 ">
           <button
             onClick={handleNewGame}
-            className="text-slate-600 text-sm font-light "
+            className="text-slate-600 text-sm font-light"
           >
-            new game
+            RESET
           </button>
         </div>
       </div>

--- a/src/dataflow/othello/othello.ts
+++ b/src/dataflow/othello/othello.ts
@@ -194,7 +194,7 @@ const apply =
 
 type State = {
   state: GameState;
-  gameMode: GAME_MODE;
+  gameMode: GAME_MODE | undefined;
   moveHistory: MoveHistory[];
   index: number;
 };
@@ -214,7 +214,7 @@ type Actions = {
 
 const useOthello = create<State & Actions>((set, get) => ({
   state: initialState,
-  gameMode: GAME_MODE.PVP,
+  gameMode: undefined,
   update: (fieldId: number) => {
     const stateBefore = get().state;
 
@@ -238,6 +238,10 @@ const useOthello = create<State & Actions>((set, get) => ({
       putAt: fieldId,
       flipped,
     });
+
+    set((state) => ({
+      gameMode: state.gameMode ?? GAME_MODE.PVP,
+    }));
   },
   skip: () => {
     set((state) => ({
@@ -246,7 +250,13 @@ const useOthello = create<State & Actions>((set, get) => ({
     const stateBefore = get().state;
     get().pushHistory(stateBefore.color, { type: "skip" });
   },
-  reset: () => set({ state: initialState, moveHistory: [], index: -1 }),
+  reset: () =>
+    set({
+      state: initialState,
+      gameMode: undefined,
+      moveHistory: [],
+      index: -1,
+    }),
   activateBot: async () => {
     const state = get().state;
     const isBotTurn = state.players[state.color].type === "bot";
@@ -315,7 +325,7 @@ const useOthello = create<State & Actions>((set, get) => ({
         state: {
           ...state.state,
           turn: state.state.turn - 1,
-          board: apply('back')(
+          board: apply("back")(
             state.state.board,
             state.moveHistory[state.index]
           ),


### PR DESCRIPTION
## 背景
現在プレー中のゲームモードが画面に表示されておらず分かりにくかった

## やったこと
- ロゴ横にゲームモードを表示
- Headerの微細な修正
  - ロゴを少し大きくした
  - `new game`→`RESET`に変更