### PR TITLE
コマを置けるマスではカーソルが変化するようにした

### DIFF
--- a/src/components/PlayGround/elements/Board/Board.tsx
+++ b/src/components/PlayGround/elements/Board/Board.tsx
@@ -4,12 +4,20 @@ import Field, { FieldObject } from "./Field";
 export type BoardData = Array<FieldObject>;
 
 const Board: React.FC = () => {
-  const { state } = useOthello();
+  const { state, getAnalysis } = useOthello();
+  const { selectableFields } = getAnalysis();
   return (
     <>
       <div className="sm:w-96 sm:h-96 w-[90vmin] h-[90vmin] max-h-96 max-w-[24rem] bg-slate-200 grid grid-cols-8 gap-1 p-2 rounded-lg shadow-[5px_5px_5px_#bebebe,-5px_-5px_5px_#ffffff]">
         {state.board.map((content: any, index: number) => {
-          return <Field key={index} fieldId={index} content={content} />;
+          return (
+            <Field
+              key={index}
+              fieldId={index}
+              content={content}
+              isSelectable={selectableFields.includes(index)}
+            />
+          );
         })}
       </div>
     </>

--- a/src/components/PlayGround/elements/Board/Field.tsx
+++ b/src/components/PlayGround/elements/Board/Field.tsx
@@ -10,14 +10,25 @@ export type FieldId = number;
 type Props = {
   fieldId: FieldId;
   content: ColorCode;
+  isSelectable: boolean;
 };
+
+const style =
+  "bg-slate-200 rounded-sm shadow-x2s flex items-center justify-center box-content";
 
 // TODO: メモ化
 const Field: React.FC<Props> = (props) => {
   const { update } = useOthello();
-  return (
+  return props.isSelectable ? (
+    <button
+      className={style}
+      onClick={!props.content ? () => update(props.fieldId) : undefined}
+    >
+      {props.content ? <Stone color={props.content} /> : null}
+    </button>
+  ) : (
     <div
-      className="bg-slate-200 rounded-sm shadow-x2s flex items-center justify-center"
+      className={style}
       onClick={!props.content ? () => update(props.fieldId) : undefined}
     >
       {props.content ? <Stone color={props.content} /> : null}

--- a/src/dataflow/othello/othello.ts
+++ b/src/dataflow/othello/othello.ts
@@ -8,7 +8,7 @@ import {
   COLOR_CODES,
   flip,
 } from "../../components/PlayGround/elements/Board/Stone";
-import { countStone, rest } from "./logic/analyze";
+import { countStone, rest, selectableFields } from "./logic/analyze";
 import { move } from "./logic/core";
 import { create } from "zustand";
 import { MCTS } from "../../components/shared/hooks/bot/methods/MCTS";
@@ -210,6 +210,11 @@ type Actions = {
   redo: () => void;
   canUndo: () => boolean;
   canRedo: () => boolean;
+  getAnalysis: () => {
+    white: number;
+    black: number;
+    selectableFields: number[];
+  };
 };
 
 const useOthello = create<State & Actions>((set, get) => ({
@@ -362,6 +367,14 @@ const useOthello = create<State & Actions>((set, get) => ({
     const nextIndex = get().index + 1;
     const lastIndex = get().moveHistory.length - 1;
     return !get().state.isOver && nextIndex <= lastIndex;
+  },
+  getAnalysis: () => {
+    const state = get().state;
+    return {
+      white: countStone(state.board, COLOR_CODES.WHITE),
+      black: countStone(state.board, COLOR_CODES.BLACK),
+      selectableFields: selectableFields(state.board, state.color),
+    };
   },
 }));
 


### PR DESCRIPTION
## 背景
- マスにホバーした際コマを置けるかどうかにかかわらずデフォルトのポインターが表示されておりわかりにくかった
- すべてのマスがdivで実装されておりマークアップやアクセシビリティとしても適切ではなかった

## やったこと
- コマを置ける場合はbuttonタグを使うようにした
  - 結果的にカーソルも適切なものが表示されるようになった