### PR TITLE
ゲーム進行に関するロジックをオブジェクト指向でリファクタする

### DIFF
--- a/src/dataflow/othello/othello.ts
+++ b/src/dataflow/othello/othello.ts
@@ -95,7 +95,6 @@ const useOthello = create<State & Actions>((set, get) => ({
   state: initialState,
   gameMode: undefined,
   update: (fieldId: number) => {
-    const stateBefore = get().state;
     set((state) => {
       const updated = othelloReducer(state.state, { type: 'update', fieldId });
       return {
@@ -110,17 +109,6 @@ const useOthello = create<State & Actions>((set, get) => ({
         },
       };
     });
-    const stateAfter = get().state;
-
-    const initialValue = [] as number[];
-    const flipped = stateBefore.board.reduce((indexes, element, index) => {
-      return element !== stateAfter.board[index] && index !== fieldId
-        ? [...indexes, index]
-        : indexes;
-    }, initialValue);
-    if (flipped.length === 0) {
-      return;
-    }
 
     set((state) => ({
       gameMode: state.gameMode ?? GAME_MODE.PVP,

--- a/src/dataflow/othello/othello.ts
+++ b/src/dataflow/othello/othello.ts
@@ -1,6 +1,5 @@
 import { BoardData } from '@models/Board/Board';
 import { FieldId } from '../../components/PlayGround/elements/Board/Field';
-import { flip } from '@models/Board/Color';
 import { create } from 'zustand';
 import { MCTS } from '../../components/shared/hooks/bot/methods/MCTS';
 import { Board } from '../../models/Board/Board';
@@ -63,8 +62,6 @@ type clearAction = {
 
 type Action = updateAction | skipAction | clearAction;
 
-export type OthelloDispatcher = React.Dispatch<Action>;
-
 // 初期値
 let initialGame = Othello.initialize();
 
@@ -94,11 +91,7 @@ const othelloReducer = (state: GameState, action: Action): GameState => {
       return result.when({
         success: (nextGame) => {
           return {
-            isOver: nextGame.isOver(),
-            isSkipped: false,
-            turn: nextGame.turnNumber,
-            board: nextGame.board.toArray(),
-            color: nextGame.color,
+            ...nextGame.toArray(),
             players: state.players,
             isInitialized: true, // プレーを開始したら初期化済みとする
           };
@@ -113,11 +106,7 @@ const othelloReducer = (state: GameState, action: Action): GameState => {
     case 'skip':
       const nextGame = othello.skip();
       return {
-        isOver: nextGame.isOver(),
-        isSkipped: true,
-        turn: nextGame.turnNumber,
-        board: nextGame.board.toArray(),
-        color: nextGame.color,
+        ...nextGame.toArray(),
         players: state.players,
         isInitialized: state.isInitialized,
       };

--- a/src/dataflow/othello/othello.ts
+++ b/src/dataflow/othello/othello.ts
@@ -91,6 +91,10 @@ type Actions = {
   };
 };
 
+/**
+ * オセロのゲーム状態管理と更新関数を提供するhooks
+ * ゲームルールはothelloReducerに委譲し、状態管理や描画に必要な情報などを扱う
+ */
 const useOthello = create<State & Actions>((set, get) => ({
   state: initialState,
   gameMode: undefined,
@@ -109,7 +113,7 @@ const useOthello = create<State & Actions>((set, get) => ({
         },
       };
     });
-
+    // ゲームモードが明示的に設定されなかった場合はPVPとして扱う
     set((state) => ({
       gameMode: state.gameMode ?? GAME_MODE.PVP,
     }));

--- a/src/dataflow/othello/othello.ts
+++ b/src/dataflow/othello/othello.ts
@@ -4,7 +4,11 @@ import { create } from 'zustand';
 import { MCTS } from '../../components/shared/hooks/bot/methods/MCTS';
 import { Board } from '../../models/Board/Board';
 import { COLOR_CODE } from '@models/Board/Color';
-import { Othello } from '@models/Game/Othello';
+import {
+  initialOthelloState,
+  othelloReducer,
+  OthelloState,
+} from './othelloReducer';
 
 type Player = {
   name: string;
@@ -32,12 +36,7 @@ const initBot = (): Player => {
   };
 };
 
-type GameState = {
-  isOver: boolean;
-  isSkipped: boolean;
-  turn: number;
-  board: BoardData;
-  color: COLOR_CODE;
+type GameState = OthelloState & {
   error?: {
     hasError: boolean;
     message?: any;
@@ -47,74 +46,13 @@ type GameState = {
   isInitialized: boolean;
 };
 
-type updateAction = {
-  type: 'update';
-  fieldId: number;
-};
-
-type skipAction = {
-  type: 'skip';
-};
-
-type clearAction = {
-  type: 'clear';
-};
-
-type Action = updateAction | skipAction | clearAction;
-
-// 初期値
-let initialGame = Othello.initialize();
-
 const initialState: GameState = {
-  isOver: false,
-  isSkipped: false,
-  turn: initialGame.turnNumber,
-  board: initialGame.board.toArray(),
-  color: initialGame.color,
+  ...initialOthelloState,
   players: {
     [COLOR_CODE.WHITE]: initPlayer('WHITE'),
     [COLOR_CODE.BLACK]: initPlayer('BLACK'),
   },
   isInitialized: false,
-};
-
-const othelloReducer = (state: GameState, action: Action): GameState => {
-  const othello = Othello.reconstruct(
-    state.turn,
-    state.board,
-    state.color,
-    state.isSkipped ? 1 : 0
-  );
-  switch (action.type) {
-    case 'update':
-      const result = othello.move(action.fieldId);
-      return result.when({
-        success: (nextGame) => {
-          return {
-            ...nextGame.toArray(),
-            players: state.players,
-            isInitialized: true, // プレーを開始したら初期化済みとする
-          };
-        },
-        failure: (_) => {
-          return {
-            ...state,
-            error: { hasError: true, message: '置けませんでした！' },
-          };
-        },
-      });
-    case 'skip':
-      const nextGame = othello.skip();
-      return {
-        ...nextGame.toArray(),
-        players: state.players,
-        isInitialized: state.isInitialized,
-      };
-    case 'clear':
-      return initialState;
-    default:
-      return state;
-  }
 };
 
 export enum GAME_MODE {
@@ -158,10 +96,20 @@ const useOthello = create<State & Actions>((set, get) => ({
   gameMode: undefined,
   update: (fieldId: number) => {
     const stateBefore = get().state;
-
-    set((state) => ({
-      state: othelloReducer(state.state, { type: 'update', fieldId }),
-    }));
+    set((state) => {
+      const updated = othelloReducer(state.state, { type: 'update', fieldId });
+      return {
+        state: {
+          ...updated,
+          isInitialized: true, // プレーを開始したら初期化済みとする
+          players: state.state.players,
+          error:
+            updated.updatedFieldIdList.length === 0  // 一つも返していない場合は失敗扱いする
+              ? { hasError: true, message: '置けませんでした！' }
+              : { hasError: false },
+        },
+      };
+    });
     const stateAfter = get().state;
 
     const initialValue = [] as number[];
@@ -180,7 +128,10 @@ const useOthello = create<State & Actions>((set, get) => ({
   },
   skip: () => {
     set((state) => ({
-      state: othelloReducer(state.state, { type: 'skip' }),
+      state: {
+        ...state.state,
+        ...othelloReducer(state.state, { type: 'skip' }),
+      },
     }));
   },
   reset: () =>

--- a/src/dataflow/othello/othelloReducer.ts
+++ b/src/dataflow/othello/othelloReducer.ts
@@ -32,6 +32,13 @@ export const initialOthelloState: OthelloState = {
   updatedFieldIdList: [],
 };
 
+/**
+ * オセロの状態を更新するReducer
+ * ターンをまたいでオセロのルールを司る
+ * @param state
+ * @param action
+ * @returns
+ */
 export const othelloReducer = (
   state: OthelloState,
   action: Action

--- a/src/dataflow/othello/othelloReducer.ts
+++ b/src/dataflow/othello/othelloReducer.ts
@@ -1,0 +1,74 @@
+import { BoardData } from '@models/Board/Board';
+import { COLOR_CODE } from '@models/Board/Color';
+import { Othello } from '@models/Game/Othello';
+
+export type OthelloState = {
+  isOver: boolean;
+  isSkipped: boolean;
+  turn: number;
+  board: BoardData;
+  color: COLOR_CODE;
+  updatedFieldIdList: number[];
+};
+
+type updateAction = {
+  type: 'update';
+  fieldId: number;
+};
+
+type skipAction = {
+  type: 'skip';
+};
+
+type clearAction = {
+  type: 'clear';
+};
+
+type Action = updateAction | skipAction | clearAction;
+
+// 初期値
+export const initialOthelloState: OthelloState = {
+  ...Othello.initialize().toArray(),
+  updatedFieldIdList: [],
+};
+
+export const othelloReducer = (
+  state: OthelloState,
+  action: Action
+): OthelloState => {
+  const othello = Othello.reconstruct(
+    state.turn,
+    state.board,
+    state.color,
+    state.isSkipped ? 1 : 0
+  );
+  switch (action.type) {
+    case 'update':
+      const result = othello.move(action.fieldId);
+      return result.when({
+        success: (nextGame) => {
+          return {
+            ...nextGame.toArray(),
+            // TODO: ひっくり返された石の位置も含むようにする
+            updatedFieldIdList: [action.fieldId],
+          };
+        },
+        failure: (_) => {
+          return {
+            ...state,
+            updatedFieldIdList: [],
+          };
+        },
+      });
+    case 'skip':
+      const nextGame = othello.skip();
+      return {
+        ...nextGame.toArray(),
+        updatedFieldIdList: [],
+      };
+    case 'clear':
+      return initialOthelloState;
+    default:
+      return state;
+  }
+};

--- a/src/dataflow/othello/othelloReducer.ts
+++ b/src/dataflow/othello/othelloReducer.ts
@@ -46,11 +46,14 @@ export const othelloReducer = (
     case 'update':
       const result = othello.move(action.fieldId);
       return result.when({
-        success: (nextGame) => {
+        success: (next) => {
           return {
-            ...nextGame.toArray(),
-            // TODO: ひっくり返された石の位置も含むようにする
-            updatedFieldIdList: [action.fieldId],
+            ...next.toArray(),
+            // TODO: flipされたfieldIdと石を置いたfieldIdを別にして返す
+            updatedFieldIdList: [
+              action.fieldId,
+              ...getUpdatedFieldIdList(state.board, next.board.toArray()),
+            ],
           };
         },
         failure: (_) => {
@@ -61,9 +64,9 @@ export const othelloReducer = (
         },
       });
     case 'skip':
-      const nextGame = othello.skip();
+      const next = othello.skip();
       return {
-        ...nextGame.toArray(),
+        ...next.toArray(),
         updatedFieldIdList: [],
       };
     case 'clear':
@@ -72,3 +75,16 @@ export const othelloReducer = (
       return state;
   }
 };
+
+/**
+ * ２つの盤面を比較して、更新されたfieldIdのリストを返す
+ * @param before 
+ * @param after 
+ * @returns 
+ */
+const getUpdatedFieldIdList = (before: BoardData, after: BoardData) =>
+  before.reduce((indexes, element, index) => {
+    return element !== after[index]
+      ? [...indexes, index]
+      : indexes;
+  }, [] as number[]);

--- a/src/models/Game/Othello.ts
+++ b/src/models/Game/Othello.ts
@@ -1,0 +1,66 @@
+import { Board, BoardData } from '@models/Board/Board';
+import { COLOR_CODE, flip } from '@models/Board/Color';
+import { Result } from '@models/Shared/Result';
+
+export class Othello {
+  private constructor(
+    public readonly turnNumber: number,
+    public readonly board: Board,
+    public readonly color: COLOR_CODE,
+    public readonly skipCount: number
+  ) {}
+
+  public static initialize(): Othello {
+    return new Othello(1, Board.initialize(), COLOR_CODE.WHITE, 0);
+  }
+
+  public static reconstruct(
+    turnNumber: number,
+    board: BoardData,
+    color: COLOR_CODE,
+    skipCount: number
+  ): Othello {
+    return new Othello(turnNumber, Board.fromArray(board), color, skipCount);
+  }
+
+
+  // Note: execute(action: Action): Result<Othello, Error> のようなインターフェースにしてもいいかも
+  public move(fieldId: number): Result<Othello, Error> {
+    if (this.isOver()) {
+      return Result.failure(new Error('Game is over'));
+    }
+
+    // 更新
+    return this.board.update(fieldId, this.color).when({
+      success: (newBoard) =>
+        Result.success(
+          new Othello(this.turnNumber + 1, newBoard, flip(this.color), 0) // skipCountをリセット
+        ),
+      failure: () => Result.failure(new Error('Invalid position')),
+    });
+  }
+
+  public skip() {
+    return new Othello(
+      this.turnNumber + 1,
+      this.board,
+      flip(this.color),
+      this.skipCount + 1
+    );
+  }
+
+  public isOver() {
+    return this.skipCount > 1 || !this.isContinuable();
+  }
+
+  /**
+   * ゲームを進行可能かどうかを返す
+   */
+  private isContinuable(): boolean {
+    return (
+      !this.board.isFulfilled() &&
+      this.board.countStone(COLOR_CODE.WHITE) !== 0 &&
+      this.board.countStone(COLOR_CODE.BLACK) !== 0
+    );
+  }
+}

--- a/src/models/Game/Othello.ts
+++ b/src/models/Game/Othello.ts
@@ -63,4 +63,18 @@ export class Othello {
       this.board.countStone(COLOR_CODE.BLACK) !== 0
     );
   }
+
+  /**
+   * TODO: Stateの知識を持ってしまっているのでDTOなどの別クラスに切り出す
+   * @returns {Object} Othelloの状態を表すオブジェクト
+   */
+  public toArray() {
+    return {
+      isOver: this.isOver(),
+      isSkipped: this.skipCount > 0,
+      turn: this.turnNumber,
+      board: this.board.toArray(),
+      color: this.color,
+    };
+  }
 }


### PR DESCRIPTION
1ファイルに纏めて書かれていたロジックを整理し、以下の階層構造を取るようにした
- useOthello
  - zustandによる状態管理や更新関数の提供するカスタムフック
  - UI寄りの知識を持つ
- othelloReducer
  - ターンをまたいだオセロのルールを管理
  - 状態管理やUIの知識を持たず、ターンを更新するだけの純粋関数
    - どんな設計/パラダイムでも利用可能
- Othello
  - あるターンのオセロのルールを管理するクラス
  - オブジェクト指向でロジックを記述