### PR TITLE
OTHELLO-45: stateで盤面のメタデータを保持するようにする

### DIFF
--- a/src/components/PlayGround/elements/ActionPanel/BottomPanel.tsx
+++ b/src/components/PlayGround/elements/ActionPanel/BottomPanel.tsx
@@ -1,11 +1,5 @@
-import { BoardData, EMPTY_CODE } from "@models/Board/Board";
 import React from "react";
-import { shoudSkip } from "../../../../dataflow/othello/logic/analyze";
 import useOthello from "../../../../dataflow/othello/othello";
-
-// TODO: 残りの空白のマスの数はメタデータに含めるようにして、この関数を削除する
-export const rest = (board: BoardData): number =>
-  board.filter((field) => field === EMPTY_CODE).length;
 
 const BottomPanel: React.FC = () => {
   const { state, skip } = useOthello();
@@ -14,7 +8,7 @@ const BottomPanel: React.FC = () => {
       className="text-center h-full flex flex-col justify-start items-center"
     >
       <div className="pt-6">
-        {shoudSkip(state.board, state.color) && rest(state.board) !== 0 ? (
+        {state.shouldSkip ? (
           <button
             className="block bg-sky-400 text-slate-50 p-1 w-20 rounded-md"
             onClick={() => skip()}

--- a/src/components/PlayGround/elements/Board/Board.tsx
+++ b/src/components/PlayGround/elements/Board/Board.tsx
@@ -2,8 +2,8 @@ import useOthello from "../../../../dataflow/othello/othello";
 import Field from "./Field";
 
 const Board: React.FC = () => {
-  const { state, getAnalysis } = useOthello();
-  const { selectableFields } = getAnalysis();
+  const { state } = useOthello();
+  const selectableFields = state.meta.active.selectable;
   return (
     <>
       <div className="sm:w-96 sm:h-96 w-[90vmin] h-[90vmin] max-h-96 max-w-[24rem] bg-slate-200 grid grid-cols-8 gap-1 p-2 rounded-lg shadow-[5px_5px_5px_#bebebe,-5px_-5px_5px_#ffffff]">

--- a/src/components/PlayGround/elements/InfoPanel/elements/PlayerInfo/PlayerInfo.tsx
+++ b/src/components/PlayGround/elements/InfoPanel/elements/PlayerInfo/PlayerInfo.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { shoudSkip } from "../../../../../../dataflow/othello/logic/analyze";
 import useOthello from "../../../../../../dataflow/othello/othello";
 import { COLOR_CODE } from "@models/Board/Color"
 import PlayerBar from "./PlayerBar";
@@ -16,7 +15,7 @@ const PlayerInfo: React.FC = (props) => {
     state.players[state.color].type === "human"
       ? {
           message: colorText + "プレイヤーのターンです",
-          status: shoudSkip(state.board, state.color)
+          status: state.shouldSkip
             ? "置ける場所がありません"
             : state.error?.message ?? "",
         }

--- a/src/dataflow/othello/logic/analyze.ts
+++ b/src/dataflow/othello/logic/analyze.ts
@@ -1,7 +1,0 @@
-import { Board, BoardData } from '@models/Board/Board';
-import { COLOR_CODE } from '@models/Board/Color';
-
-// TODO: 将来的には削除する
-export const shoudSkip = (board: BoardData, color: COLOR_CODE): boolean => {
-  return Board.fromArray(board).selectableFields(color).length === 0;
-};

--- a/src/dataflow/othello/metadata.ts
+++ b/src/dataflow/othello/metadata.ts
@@ -1,0 +1,46 @@
+import { Board, FieldId } from '@models/Board/Board';
+import { COLOR_CODE } from '@models/Board/Color';
+
+// オセロに関するメタデータを定義する
+// TODO: アクセスしやすさや拡張性を考慮してデータ構造を見直す
+export type MetaData = {
+  board: {
+    white: {
+      stones: number;
+      selectable: FieldId[];
+    };
+    black: {
+      stones: number;
+      selectable: FieldId[];
+    };
+    isFulfilled: boolean;
+  };
+  active: {
+    color: COLOR_CODE;
+    stones: number;
+    selectable: FieldId[];
+  };
+};
+
+// 盤面のメタデータを生成する
+// TODO: アクティブなプレイヤーの情報の計算はselectorなどに切り出す
+export const createMetaData = (board: Board, activeColor: COLOR_CODE): MetaData => {
+  const boardMetaData = {
+    white: {
+      stones: board.countStone(COLOR_CODE.WHITE),
+      selectable: board.selectableFields(COLOR_CODE.WHITE),
+    },
+    black: {
+      stones: board.countStone(COLOR_CODE.BLACK),
+      selectable: board.selectableFields(COLOR_CODE.BLACK),
+    },
+    isFulfilled: board.isFulfilled(),
+  };
+  return {
+    board: boardMetaData,
+    active: {
+      color: activeColor,
+      ...boardMetaData[activeColor === COLOR_CODE.WHITE ? 'white' : 'black'],
+    },
+  };
+};

--- a/src/dataflow/othello/othello.ts
+++ b/src/dataflow/othello/othello.ts
@@ -2,7 +2,6 @@ import { BoardData } from '@models/Board/Board';
 import { FieldId } from '../../components/PlayGround/elements/Board/Field';
 import { create } from 'zustand';
 import { MCTS } from '../../components/shared/hooks/bot/methods/MCTS';
-import { Board } from '../../models/Board/Board';
 import { COLOR_CODE } from '@models/Board/Color';
 import {
   initialOthelloState,
@@ -84,11 +83,6 @@ type Actions = {
   reset: () => void;
   activateBot: () => void;
   initialize: (settings: GameSettings) => void;
-  getAnalysis: () => {
-    white: number;
-    black: number;
-    selectableFields: number[];
-  };
 };
 
 /**
@@ -174,15 +168,6 @@ const useOthello = create<State & Actions>((set, get) => ({
       },
       gameMode: settings.gameMode,
     });
-  },
-  getAnalysis: () => {
-    const state = get().state;
-    const board = Board.fromArray(state.board);
-    return {
-      white: board.countStone(COLOR_CODE.WHITE),
-      black: board.countStone(COLOR_CODE.BLACK),
-      selectableFields: board.selectableFields(state.color),
-    };
   },
 }));
 

--- a/src/dataflow/othello/othelloReducer.ts
+++ b/src/dataflow/othello/othelloReducer.ts
@@ -1,6 +1,7 @@
 import { BoardData } from '@models/Board/Board';
 import { COLOR_CODE } from '@models/Board/Color';
 import { Othello } from '@models/Game/Othello';
+import { createMetaData, MetaData } from './metadata';
 
 export type OthelloState = {
   isOver: boolean;
@@ -9,6 +10,7 @@ export type OthelloState = {
   board: BoardData;
   color: COLOR_CODE;
   updatedFieldIdList: number[];
+  meta: MetaData;
 };
 
 type updateAction = {
@@ -27,8 +29,10 @@ type clearAction = {
 type Action = updateAction | skipAction | clearAction;
 
 // 初期値
+const initailOthello: Othello = Othello.initialize();
 export const initialOthelloState: OthelloState = {
-  ...Othello.initialize().toArray(),
+  ...initailOthello.toArray(),
+  meta: createMetaData(initailOthello.board, initailOthello.color),
   updatedFieldIdList: [],
 };
 
@@ -61,6 +65,7 @@ export const othelloReducer = (
               action.fieldId,
               ...getUpdatedFieldIdList(state.board, next.board.toArray()),
             ],
+            meta: createMetaData(next.board, next.color),
           };
         },
         failure: (_) => {
@@ -75,6 +80,7 @@ export const othelloReducer = (
       return {
         ...next.toArray(),
         updatedFieldIdList: [],
+        meta: createMetaData(initailOthello.board, next.color),
       };
     case 'clear':
       return initialOthelloState;

--- a/src/dataflow/othello/othelloReducer.ts
+++ b/src/dataflow/othello/othelloReducer.ts
@@ -10,6 +10,7 @@ export type OthelloState = {
   board: BoardData;
   color: COLOR_CODE;
   updatedFieldIdList: number[];
+  shouldSkip: boolean;
   meta: MetaData;
 };
 

--- a/src/models/Game/Othello.ts
+++ b/src/models/Game/Othello.ts
@@ -49,6 +49,10 @@ export class Othello {
     );
   }
 
+  public shoudSkip() {
+    return !this.isOver && this.board.selectableFields(this.color).length === 0;
+  }
+
   public isOver() {
     return this.skipCount > 1 || !this.isContinuable();
   }
@@ -75,6 +79,7 @@ export class Othello {
       turn: this.turnNumber,
       board: this.board.toArray(),
       color: this.color,
+      shouldSkip: this.shoudSkip(),
     };
   }
 }


### PR DESCRIPTION
コンポーネント側でビジネスロジックを呼び出さずに盤面の解析情報にアクセスできるようにする

やったこと
- stateにメタデータを追加し、盤面情報を格納するようにした
- コンポーネントでメタデータを参照するようにした
- メタデータで代用できる関数を削除