### PR TITLE
OTHELLO-51: reducerの入出力にモデルを使うようにした

### DIFF
--- a/src/dataflow/othello/othello.ts
+++ b/src/dataflow/othello/othello.ts
@@ -35,7 +35,7 @@ const initBot = (): Player => {
 
 type OthelloState = {
   isOver: boolean;
-  isSkipped: boolean;
+  skipCount: number;
   turn: number;
   board: BoardData;
   color: COLOR_CODE;
@@ -108,7 +108,7 @@ const useOthello = create<State & Actions>((set, get) => ({
         state.state.turn,
         state.state.board,
         state.state.color,
-        state.state.isSkipped ? 1 : 0
+        state.state.skipCount
       );
       const updated = othelloReducer(current, { type: 'update', fieldId });
       return {
@@ -135,7 +135,7 @@ const useOthello = create<State & Actions>((set, get) => ({
         state.state.turn,
         state.state.board,
         state.state.color,
-        state.state.isSkipped ? 1 : 0
+        state.state.skipCount
       );
       const updated = othelloReducer(current, { type: 'skip' });
       return {
@@ -146,7 +146,7 @@ const useOthello = create<State & Actions>((set, get) => ({
           players: state.state.players,
           error:
             updated.turnNumber === current.turnNumber // ターンが進まなかった場合は失敗
-              ? { hasError: true, message: 'スキップできませんでした！' }
+              ? { hasError: true, message: 'このターンはスキップできません！' }
               : { hasError: false },
         },
       };

--- a/src/dataflow/othello/othelloReducer.ts
+++ b/src/dataflow/othello/othelloReducer.ts
@@ -1,18 +1,4 @@
-import { BoardData } from '@models/Board/Board';
-import { COLOR_CODE } from '@models/Board/Color';
 import { Othello } from '@models/Game/Othello';
-import { createMetaData, MetaData } from './metadata';
-
-export type OthelloState = {
-  isOver: boolean;
-  isSkipped: boolean;
-  turn: number;
-  board: BoardData;
-  color: COLOR_CODE;
-  updatedFieldIdList: number[];
-  shouldSkip: boolean;
-  meta: MetaData;
-};
 
 type updateAction = {
   type: 'update';
@@ -29,14 +15,6 @@ type clearAction = {
 
 type Action = updateAction | skipAction | clearAction;
 
-// 初期値
-const initailOthello: Othello = Othello.initialize();
-export const initialOthelloState: OthelloState = {
-  ...initailOthello.toArray(),
-  meta: createMetaData(initailOthello.board, initailOthello.color),
-  updatedFieldIdList: [],
-};
-
 /**
  * オセロの状態を更新するReducer
  * ターンをまたいでオセロのルールを司る
@@ -44,71 +22,21 @@ export const initialOthelloState: OthelloState = {
  * @param action
  * @returns
  */
-export const othelloReducer = (
-  state: OthelloState,
-  action: Action
-): OthelloState => {
-  const othello = Othello.reconstruct(
-    state.turn,
-    state.board,
-    state.color,
-    state.isSkipped ? 1 : 0
-  );
+export const othelloReducer = (current: Othello, action: Action): Othello => {
   switch (action.type) {
     case 'update':
-      const result = othello.move(action.fieldId);
+      const result = current.move(action.fieldId);
       return result.when({
-        success: (next) => {
-          return {
-            ...next.toArray(),
-            // TODO: flipされたfieldIdと石を置いたfieldIdを別にして返す
-            updatedFieldIdList: [
-              action.fieldId,
-              ...getUpdatedFieldIdList(state.board, next.board.toArray()),
-            ],
-            meta: createMetaData(next.board, next.color),
-          };
-        },
-        failure: () => {
-          return {
-            ...state,
-            updatedFieldIdList: [],
-          };
-        },
+        success: (next) => next,
+        failure: () => current,
       });
     case 'skip':
-      const skipResult = othello.skip();
+      const skipResult = current.skip();
       return skipResult.when({
-        success: (next) => {
-          return {
-            ...next.toArray(),
-            updatedFieldIdList: [],
-            meta: createMetaData(next.board, next.color),
-          };
-        },
-        failure: () => {
-          return {
-            ...state,
-            updatedFieldIdList: [],
-          };
-        },
+        success: (next) => next,
+        failure: () => current,
       });
     case 'clear':
-      return initialOthelloState;
-    default:
-      return state;
+      return Othello.initialize();
   }
 };
-
-/**
- * ２つの盤面を比較して、更新されたfieldIdのリストを返す
- * @param before 
- * @param after 
- * @returns 
- */
-const getUpdatedFieldIdList = (before: BoardData, after: BoardData) =>
-  before.reduce((indexes, element, index) => {
-    return element !== after[index]
-      ? [...indexes, index]
-      : indexes;
-  }, [] as number[]);

--- a/src/models/Game/Othello.ts
+++ b/src/models/Game/Othello.ts
@@ -23,8 +23,6 @@ export class Othello {
     return new Othello(turnNumber, Board.fromArray(board), color, skipCount);
   }
 
-
-  // Note: execute(action: Action): Result<Othello, Error> のようなインターフェースにしてもいいかも
   public move(fieldId: number): Result<Othello, Error> {
     if (this.isOver()) {
       return Result.failure(new Error('Game is over'));
@@ -81,7 +79,7 @@ export class Othello {
   public toArray() {
     return {
       isOver: this.isOver(),
-      isSkipped: this.skipCount > 0,
+      skipCount: this.skipCount,
       turn: this.turnNumber,
       board: this.board.toArray(),
       color: this.color,


### PR DESCRIPTION
## やったこと
- reducerの引数と戻り値をOthelloクラスにした
    - stateがいっぱいでややこしいためreducerのstateは廃止
        - `(Othello, Action) ⇒ Othello`にする
    - 代わりにカスタムフックでstateを定義した

## やらなかったこと
- stateの整理
  - state内に様々な関心事が混在しているため将来的にリファクタしたい
  - redux toolkitのmiddlewareで主要なデータとそこから計算可能なサブデータ(メタデータ等)を分離するアプローチを検討中