### PR TITLE
OTHELLO-52: 

### DIFF
--- a/src/components/PlayGround/elements/InfoPanel/elements/PlayerInfo/PlayerInfo.tsx
+++ b/src/components/PlayGround/elements/InfoPanel/elements/PlayerInfo/PlayerInfo.tsx
@@ -5,14 +5,14 @@ import { COLOR_CODE } from "@models/Board/Color"
 import PlayerBar from "./PlayerBar";
 
 const PlayerInfo: React.FC = (props) => {
-  const { state } = useOthello();
+  const { state, players } = useOthello();
 
   const colorText = state.color === COLOR_CODE.WHITE ? "白" : "黒";
   const theme = state.color === COLOR_CODE.WHITE ? "light" : "dark";
-  const name = state.players[state.color].name;
+  const name = players.active.name;
 
   const data =
-    state.players[state.color].type === "human"
+    players.active.type === "human"
       ? {
           message: colorText + "プレイヤーのターンです",
           status: state.shouldSkip

--- a/src/components/PlayGround/elements/InfoPanel/elements/ResultInfo/ResultInfo.tsx
+++ b/src/components/PlayGround/elements/InfoPanel/elements/ResultInfo/ResultInfo.tsx
@@ -12,7 +12,7 @@ export const countStone = (board: BoardData, color: COLOR_CODE): number =>
   board.filter((field) => field === color).length;
 
 const ResultInfo: React.FC = () => {
-  const { state, gameMode } = useOthello();
+  const { state, gameMode, players } = useOthello();
 
   const counts = {
     white: countStone(state.board, COLOR_CODE.WHITE),
@@ -54,8 +54,8 @@ const ResultInfo: React.FC = () => {
         {winner === undefined
           ? "DRAW"
           : gameMode === "PVP"
-          ? state.players[winner].name + " WIN!"
-          : state.players[winner].type === "human"
+          ? players[winner].name + " WIN!"
+          : players[winner].type === "human"
           ? "YOU WIN!"
           : "YOU LOSE..."}
       </h2>

--- a/src/dataflow/othello/othello.ts
+++ b/src/dataflow/othello/othello.ts
@@ -37,6 +37,12 @@ const initBot = (): Player => {
   };
 };
 
+const initialPlayers: Players = {
+  [COLOR_CODE.WHITE]: initPlayer('WHITE'),
+  [COLOR_CODE.BLACK]: initPlayer('BLACK'),
+  active: initPlayer('WHITE'),
+};
+
 type OthelloState = {
   isOver: boolean;
   skipCount: number;
@@ -83,7 +89,7 @@ type GameSettings = PvPSettings | PvESettings;
 
 type State = {
   state: GameState;
-  gameMode: GAME_MODE | undefined;
+  gameMode: GAME_MODE;
   players: Players;
 };
 
@@ -101,13 +107,8 @@ type Actions = {
  */
 const useOthello = create<State & Actions>((set, get) => ({
   state: initialState,
-  gameMode: undefined,
-  players: {
-    // TODO: selectByColor()を実装する
-    [COLOR_CODE.WHITE]: initPlayer('WHITE'),
-    [COLOR_CODE.BLACK]: initPlayer('BLACK'),
-    active: initPlayer('WHITE'),
-  },
+  gameMode: GAME_MODE.PVP, // デフォルトをPVPに設定
+  players: initialPlayers,
   update: (fieldId: number) => {
     set((state) => {
       const current = Othello.reconstruct(
@@ -133,10 +134,6 @@ const useOthello = create<State & Actions>((set, get) => ({
         },
       };
     });
-    // ゲームモードが明示的に設定されなかった場合はPVPとして扱う
-    set((state) => ({
-      gameMode: state.gameMode ?? GAME_MODE.PVP,
-    }));
   },
   skip: () => {
     set((state) => {
@@ -167,7 +164,8 @@ const useOthello = create<State & Actions>((set, get) => ({
   reset: () =>
     set({
       state: initialState,
-      gameMode: undefined,
+      gameMode: GAME_MODE.PVP,
+      players: initialPlayers,
     }),
   activateBot: async () => {
     const state = get().state;


### PR DESCRIPTION
## やったこと
- playersをstateのトップに移動
- players.activeで現在アクティブなプレイヤーの情報にアクセスしやすくした

当初はカスタムフックのインターフェースの変更まで見込んでいたが、いったんプレイヤー情報のリファクタだけ切り出すことにした