### PR TITLE
OTHELLO-69: ゲームのstatusとresultを追加し、勝敗判定とコンポーネントの出し分けをシンプルにした

### DIFF
--- a/src/components/PlayGround/elements/InfoPanel/InfoPanel.tsx
+++ b/src/components/PlayGround/elements/InfoPanel/InfoPanel.tsx
@@ -6,12 +6,16 @@ import ResultInfo from "./elements/ResultInfo/ResultInfo";
 import SettingsInfo from "./elements/SettingsInfo/SettingsInfo";
 
 const InfoPanel: React.FC = () => {
-  const { state } = useOthello();
+  const gameStatus = useOthello(state => state.game.status);
 
-  if (!state.isInitialized) {
-    return <SettingsInfo />;
+  switch (gameStatus) {
+    case "not_started":
+      return <SettingsInfo />;
+    case "playing":
+      return <PlayerInfo />;
+    case "finished":
+      return <ResultInfo />;
   }
-  return state.isOver ? <ResultInfo /> : <PlayerInfo />;
 };
 
 export default InfoPanel;

--- a/src/components/PlayGround/elements/InfoPanel/elements/ResultInfo/ResultInfo.tsx
+++ b/src/components/PlayGround/elements/InfoPanel/elements/ResultInfo/ResultInfo.tsx
@@ -1,68 +1,31 @@
 "use client";
 
 import useOthello from "../../../../../../dataflow/othello/useOthello";
-import { BoardData } from "@models/Board/Board";
-import { COLOR_CODE } from "@models/Board/Color"
 import ResultBar from "./ResultBar";
 
-const TOTAL_STONES = 64;
-
-// FIXME: 結果はメタデータに持たせて以下の処理はすべて削除する
-export const countStone = (board: BoardData, color: COLOR_CODE): number =>
-  board.filter((field) => field === color).length;
-
 const ResultInfo: React.FC = () => {
-  const { state, gameMode, players } = useOthello();
+  const { game, gameMode, players, state } = useOthello();
 
-  const counts = {
-    white: countStone(state.board, COLOR_CODE.WHITE),
-    black: countStone(state.board, COLOR_CODE.BLACK),
-  };
-
-  const getWinner = (board: BoardData): COLOR_CODE | undefined => {
-    const counts = {
-      white: countStone(state.board, COLOR_CODE.WHITE),
-      black: countStone(state.board, COLOR_CODE.BLACK),
-    };
-
-    const isFinished = counts.white + counts.black === TOTAL_STONES;
-    const isDraw = counts.white === counts.black;
-    const isDominated = counts.white === 0 || counts.black === 0;
-
-    if (isFinished) {
-      // 全てのマスが埋まっている場合
-      return isDraw
-        ? undefined
-        : counts.white > counts.black
-        ? COLOR_CODE.WHITE
-        : COLOR_CODE.BLACK;
-    } else {
-      // 途中で終了した場合
-      return isDominated
-        ? counts.white > counts.black
-          ? COLOR_CODE.WHITE
-          : COLOR_CODE.BLACK
-        : undefined;
-    }
-  };
-
-  const winner = getWinner(state.board);
+  let text = "";
+  switch (game.result?.type) {
+    case "resulted":
+      text = gameMode === "PVP"
+        ? players[game.result.winner].name + " WIN!"
+        : players[game.result.winner].type === "human" ? "YOU WIN!" : "YOU LOSE...";
+      break;
+    case "draw":
+      text = "DRAW";
+      break;
+  }
 
   return (
     <div className=" h-full text-center flex flex-col items-center sm:justify-center pb-6 sm:pt-6 pt-10">
       <h2 className="text-slate-600 font-bold text-xl mb-6">
-        {winner === undefined
-          ? "DRAW"
-          : gameMode === "PVP"
-          ? players[winner].name + " WIN!"
-          : players[winner].type === "human"
-          ? "YOU WIN!"
-          : "YOU LOSE..."}
+        {text}
       </h2>
       <div className="mb-1">
-        <ResultBar counts={counts} />
+        <ResultBar counts={{ white: state.meta.board.white.stones, black: state.meta.board.black.stones }} />
       </div>
-      <p className="text-xs text-slate-400 animate-pulse"></p>
     </div>
   );
 };


### PR DESCRIPTION
stateのトップレベルにgameを追加し、statusとresultを記録するようにした

後続のPRでstate全体の再設計を行う